### PR TITLE
use kotlin-stdlib-jdk8 (jre* versions are deprecated)

### DIFF
--- a/klogging.jvm/build.gradle
+++ b/klogging.jvm/build.gradle
@@ -14,7 +14,7 @@ sourceSets {
 }
 
 dependencies {
-    compile "org.jetbrains.kotlin:kotlin-stdlib-jre8:$kotlin_version"
+    compile "org.jetbrains.kotlin:kotlin-stdlib-jdk8:$kotlin_version"
     compile "org.slf4j:slf4j-api:$sl4j_version"
     expectedBy project(':klogging.common')
 }


### PR DESCRIPTION
Inclusion of the `kotlin-stdlib-jre8` library causes later Kotlin compiler versions to warn that the stdlib-jre7 and stdlib-jre8 versions have been deprecated.